### PR TITLE
UI issues in color select

### DIFF
--- a/lib/presentation/widgets/color_select.dart
+++ b/lib/presentation/widgets/color_select.dart
@@ -39,15 +39,16 @@ class _OpenFlutterColorSelectState extends State<OpenFlutterColorSelect> {
         padding: EdgeInsets.only(bottom: AppSizes.sidePadding),
       ),
       Container(
-          padding: EdgeInsets.symmetric(vertical: AppSizes.sidePadding),
-          color: AppColors.white,
-          child: Column(children: <Widget>[
-            Container(
-              padding:
-                  EdgeInsets.symmetric(horizontal: AppSizes.sidePadding * 2),
-              child: Row(children: buildColors(context)),
-            )
-          ]))
+        padding: EdgeInsets.symmetric(
+          vertical: AppSizes.sidePadding, 
+          horizontal: AppSizes.sidePadding * 2),
+        width: width,
+        color: AppColors.white,
+        child: Wrap(
+          spacing: AppSizes.sidePadding,
+          children: buildColors(context),
+        ),
+      )
     ]);
   }
 
@@ -55,12 +56,9 @@ class _OpenFlutterColorSelectState extends State<OpenFlutterColorSelect> {
     var colorWidgets = <Widget>[];
     for (var i = 0; i < widget.availableColors.length; i++) {
       colorWidgets.add(
-        Padding(
-          padding: EdgeInsets.only(right: AppSizes.sidePadding),
-          child: InkWell(
-            onTap: (() => {updateSelectedColors(widget.availableColors[i])}),
-            child: buildColorWidget(widget.availableColors[i], context),
-          ),
+        InkWell(
+          onTap: (() => {updateSelectedColors(widget.availableColors[i])}),
+          child: buildColorWidget(widget.availableColors[i], context),
         ),
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
-  flutter_svg: 0.17.1
+  flutter_svg: ^0.17.3+1
   intl: ^0.16.0
   flutter_bloc: ^3.1.0
   equatable: ^1.1.0


### PR DESCRIPTION
It looks like items of color are more than space.
So obviously approach is to wrap into `SingleChildScrollView`

It was
![image](https://user-images.githubusercontent.com/10350366/76697971-80d4e500-66ae-11ea-8467-e690c40cc244.png)

It now
![image](https://user-images.githubusercontent.com/10350366/76697996-c85b7100-66ae-11ea-9f1b-bcc86269034c.png)

MacOS Catalina 10.15.3
Flutter 1.15.22-pre.24
Simulator iPhone 8

