### PR TITLE
Intl package upgraded to solve version mismatch with flutter_localization

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
   flutter_svg: ^0.18.1
-  intl: ^0.16.0
+  intl: ^0.17.0-nullsafety.2
   flutter_translate: any
   bubble_tab_indicator: any
   http: ^0.12.0+4


### PR DESCRIPTION
`Intl` package current version (`^0.16.0`) does not have nullsafety feature. Since `flutter_localization` package uses latest `intl` version which support `null-safety` `pub get` failed.

See added issue: https://github.com/4seer/openflutterecommerceapp/issues/135